### PR TITLE
Refactor: Use Router Pattern to build http request

### DIFF
--- a/AlpakaTheater/AlpakaTheater.xcodeproj/project.pbxproj
+++ b/AlpakaTheater/AlpakaTheater.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		CE82E08B2C2B181700937DC7 /* SearchDetailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82E08A2C2B181700937DC7 /* SearchDetailTableViewCell.swift */; };
 		CE82E08D2C2B183200937DC7 /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82E08C2C2B183200937DC7 /* BaseTableViewCell.swift */; };
 		CE82E08F2C2B40D400937DC7 /* SearchDetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82E08E2C2B40D400937DC7 /* SearchDetailCollectionViewCell.swift */; };
+		CE82E0952C2BFF0C00937DC7 /* MovieData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82E0942C2BFF0C00937DC7 /* MovieData.swift */; };
+		CE82E0972C2BFF2200937DC7 /* ImageData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE82E0962C2BFF2200937DC7 /* ImageData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -63,6 +65,8 @@
 		CE82E08A2C2B181700937DC7 /* SearchDetailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDetailTableViewCell.swift; sourceTree = "<group>"; };
 		CE82E08C2C2B183200937DC7 /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
 		CE82E08E2C2B40D400937DC7 /* SearchDetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchDetailCollectionViewCell.swift; sourceTree = "<group>"; };
+		CE82E0942C2BFF0C00937DC7 /* MovieData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieData.swift; sourceTree = "<group>"; };
+		CE82E0962C2BFF2200937DC7 /* ImageData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -200,6 +204,8 @@
 			isa = PBXGroup;
 			children = (
 				CE82E07C2C2AC09D00937DC7 /* TMDBResponse.swift */,
+				CE82E0942C2BFF0C00937DC7 /* MovieData.swift */,
+				CE82E0962C2BFF2200937DC7 /* ImageData.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -308,6 +314,7 @@
 				CE82E08D2C2B183200937DC7 /* BaseTableViewCell.swift in Sources */,
 				CE82E0722C2AB9AB00937DC7 /* Reusable.swift in Sources */,
 				CE82E0572C2AAD2400937DC7 /* BaseViewController.swift in Sources */,
+				CE82E0952C2BFF0C00937DC7 /* MovieData.swift in Sources */,
 				CE82E0752C2ABB3C00937DC7 /* Constants.swift in Sources */,
 				CE82E07D2C2AC09D00937DC7 /* TMDBResponse.swift in Sources */,
 				CE82E0592C2AAD8E00937DC7 /* BaseView.swift in Sources */,
@@ -317,6 +324,7 @@
 				CE82E05C2C2AB1C200937DC7 /* TMDBManager.swift in Sources */,
 				CE82E07F2C2AC35500937DC7 /* SearchCollectionViewCell.swift in Sources */,
 				CE82E0402C2AAC0A00937DC7 /* SceneDelegate.swift in Sources */,
+				CE82E0972C2BFF2200937DC7 /* ImageData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AlpakaTheater/AlpakaTheater/Constants/Types.swift
+++ b/AlpakaTheater/AlpakaTheater/Constants/Types.swift
@@ -11,9 +11,10 @@ enum TMDBRequestType: Hashable {
     case searchMovie(String)
     case similarMovies(Int)
     case recommendations(Int)
+    case images(Int)
     
     
-    var url: String {
+    var baseUrl: String {
         switch self {
         case .searchMovie(_):
             return "https://api.themoviedb.org/3/search/movie"
@@ -21,6 +22,8 @@ enum TMDBRequestType: Hashable {
             return "https://api.themoviedb.org/3/movie/\(movieId)/similar"
         case .recommendations(let movieId):
             return "https://api.themoviedb.org/3/movie/\(movieId)/recommendations"
+        case .images(let movieId):
+            return  "https://api.themoviedb.org/3/movie/\(movieId)/images"
         }
     }
     
@@ -36,8 +39,9 @@ enum TMDBRequestType: Hashable {
         case .similarMovies(_), .recommendations(_):
             parameters["language"] = "ko-KR"
             parameters["page"] = "1"
+        case .images(_):
+            break
         }
-        
         return parameters
     }
 }

--- a/AlpakaTheater/AlpakaTheater/Managers/TMDBManager.swift
+++ b/AlpakaTheater/AlpakaTheater/Managers/TMDBManager.swift
@@ -14,19 +14,17 @@ final class TMDBManager {
     
     private init () { }
     
-    func fetchTMDBData(_ tmdbRequestType: TMDBRequestType, completionHandler: @escaping (TMDBResponse) -> ()) {
-        let url = tmdbRequestType.url
-        
-        let parameters: Parameters = tmdbRequestType.parameters
-        
-        let headers = TMDBAPIKey.headers
-        
+    func fetchTMDBData<T: Codable>(
+        _ tmdbRequestType: TMDBRequestType,
+        _ type: T.Type,
+        completionHandler: @escaping (T) -> ()
+    ) { 
         AF.request(
-            url,
-            parameters: parameters,
-            headers: headers
+            tmdbRequestType.baseUrl,
+            parameters: tmdbRequestType.parameters,
+            headers: TMDBAPIKey.headers
         )
-        .responseDecodable(of: TMDBResponse.self) { response in
+        .responseDecodable(of: T.self) { response in
             switch response.result {
             case .success(let value):
                 completionHandler(value)

--- a/AlpakaTheater/AlpakaTheater/Models/ImageData.swift
+++ b/AlpakaTheater/AlpakaTheater/Models/ImageData.swift
@@ -1,0 +1,14 @@
+//
+//  ImageData.swift
+//  AlpakaTheater
+//
+//  Created by user on 6/26/24.
+//
+
+struct ImageSearchResponse: Codable {
+    let backdrops: [ImageData]
+}
+
+struct ImageData: Codable {
+    let file_path: String
+}

--- a/AlpakaTheater/AlpakaTheater/Models/MovieData.swift
+++ b/AlpakaTheater/AlpakaTheater/Models/MovieData.swift
@@ -1,0 +1,15 @@
+//
+//  MovieData.swift
+//  AlpakaTheater
+//
+//  Created by user on 6/26/24.
+//
+
+struct MovieData: Codable {
+    let title: String
+    let backdrop_path: String?
+    let id: Int
+    let genre_ids: [Int]
+    let overview: String
+    let poster_path: String?
+}

--- a/AlpakaTheater/AlpakaTheater/Models/TMDBResponse.swift
+++ b/AlpakaTheater/AlpakaTheater/Models/TMDBResponse.swift
@@ -11,13 +11,3 @@ struct TMDBResponse: Codable {
     let total_pages: Int
     let total_results: Int
 }
-
-struct MovieData: Codable {
-    let title: String
-    let backdrop_path: String?
-    let id: Int
-    let genre_ids: [Int]
-    let original_title: String
-    let overview: String
-    let poster_path: String?
-}

--- a/AlpakaTheater/AlpakaTheater/Views/SearchView/SearchViewController.swift
+++ b/AlpakaTheater/AlpakaTheater/Views/SearchView/SearchViewController.swift
@@ -35,7 +35,10 @@ final class SearchViewController: BaseViewController {
 extension SearchViewController: UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         if let text = searchBar.text {
-            TMDBManager.shared.fetchTMDBData(.searchMovie(text)) { [weak self] tmdbResponse in
+            TMDBManager.shared.fetchTMDBData(
+                .searchMovie(text),
+                TMDBResponse.self
+            ) { [weak self] tmdbResponse in
                 self?.searchResults = tmdbResponse.results.filter {
                     $0.poster_path != nil
                 }
@@ -48,7 +51,6 @@ extension SearchViewController: UICollectionViewDelegate, UICollectionViewDataSo
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return searchResults.count
     }
-    
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SearchCollectionViewCell.identifier, for: indexPath) as? SearchCollectionViewCell else { return UICollectionViewCell() }


### PR DESCRIPTION
## 🎪 *Pull requests* 🦙

 🌱 **작업한 브랜치**
https://github.com/alpaka99/alpaka_theater/tree/%239/Feat/URL-Router-Pattern

<br></br>

## 🔍 **작업한 결과**
- 기존에 어느정도는 추상화 되어 있었지만, 충분히 되어있지 않았던 http request의 구조로 인해 api 요청을 보낼때 메서드를 여러개 만들거나 분기 처리를 진행할 수 밖에 없었습니다.
- 하지만 enum을 이용해서 구현한 Router Pattern과 Generic Type을 이용하여 하나의 메서드에서 다양한 API 요청에 대한 처리를 할 수 있게끔 추상화를 할 수 있었습니다. 

<br></br>
## 🔫 **Trouble Shooting**
- Alamofire의 .request 메서드에 넣어줄 값들을 다룰 수 있도록 Router Pattern을 이용해 추상화를 하였습니다. TMDBRequestType이라는 enum을 생성하여 각각의 요청들에 대한 case를 다루고 있습니다. 
- AssociatedType을 이용하여 search case에서의 검색어라던지, recommendation에서의 movieId와 같은 사용자로부터 필수적으로 입력 받아야하는 query를 enum에서 처리하고 있습니다.
- request를 보내는데에 필요한것은 크게 3가지인 baseUrl, parameters 그리고 headers로 분류하여 enum의 연산 프로퍼티로 처리하고 있습니다. 추후에 더 세밀한 조정이 필요해지면 그때마다 연산프로퍼티를 추가하여 유지보수가 더 쉽게 이뤄질 수 있도록 하는게 목표였습니다.
- headers는 항상 같은 값들인 authorization값과 요청 데이터 타입에 대한 정보가 적혀있고 아직은 변화가 없기 때문에 TMDBAPIKey에 static으로 저장하고 필요할때마다 사용하고 있습니다. 
```swift

// Router Pattern을 이용한 url 정보 조립
enum TMDBRequestType {
    // API 요청방법에 대한 case들
    case someCase(AssociatedType)

    // 1. baseURL
    var baseURL: String { 
        switch self {
          // baseURL 반환
         }
    }

    // 2. parameters
    var parameters: Parameters {
        switch self {
        // parameter  반환
    }
}

``` 
- Generic Type을 이용해서 decoding을 하는 부분도 추상화를 하였습니다. 기존에는 DecodingType을 명시적으로 적어줘야했기때문에 메서드 내에서 분기처리를 해줘야했습니다. 이 부분을 추상화하고 싶어 Router에서 meta type을 반환하려고 이틀을 고민했지만, 방법을 찾기가 힘들었습니다. 
- meta type 자체는 enum에서 반환할 수 있었지만, 추상화를 위해서 protocol의 타입으로 반환할 수 있었고, 이것은 Alamofire쪽에서 매개변수로 받는 meta type의 구체적인 타입을 유추할 수 없는 문제가 생겼습니다. 
- 그래서 fetchData 메서드 자체를 generic type을 이용한 메서드로 리팩터링 하였습니다. 사용자가 어떤 타입으로 반환 받을지 구체적인 meta type을 전달해주고, 이를 Alamofire에서 사용합니다.
- 대신 이 전달해주는 타입은 Decodable을 채택하는 타입이라면 어떤 타입이라도 가능하도록 Generic type에 제한을 해주고 있습니다.
- completionHandler로 전달해주는 값도 사용자가 입력해준 타입으로 반환해줍니다. 이 completionHandler를 받는 쪽에서 해당 반환받은 타입에 대한 처리를 해주고 있는데, 추후에 이것도 수정이 가능할지 고민해보고 싶습니다.
```swift
func fetchData<T: Decodable>(_ requestType: TMDBRequestType, _ type: T.type, completionHandler: @escaping (T) -> ()) {
    // some URL Router work...


    AF.request(url:parameters:headers:)
    .responseDecodable(of: T.self) { response in
    // some response handling action
    }
}
```   
  
<br></br>
## 🔊 기타 공유사항
- 현재 image를 가져오는 메서드는 fetchImage라는 메서드로 분리되어있습니다. 이는 KingFisher의 retrieveImage 메서드를 사용하고 있고, image의 디코딩 방법도 조금 달라서 분리해놨는데, 추후에는 이미지를 가져오는 메서드도 통합하여 리팩터링 할 수 있을것이라 생각합니다.

<br></br>
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|RouterPattern과 generic을 이용한 호출 1|![Simulator Screen Recording - iPhone 15 Pro - 2024-06-27 at 01 50 49](https://github.com/alpaka99/alpaka_theater/assets/22471820/4894fae0-d68e-46ba-ba7b-e5cad7a995d8)|
|RouterPattern과 generic을 이용한 호출 2|![Simulator Screen Recording - iPhone 15 Pro - 2024-06-27 at 01 44 03](https://github.com/alpaka99/alpaka_theater/assets/22471820/e87ae589-f666-451b-9b8f-a8173b1ceb64)|

<br></br>

## 📟 관련 이슈
- Resolved: #9 